### PR TITLE
example of a component that will break jest-styled-components

### DIFF
--- a/.storybook/config.js
+++ b/.storybook/config.js
@@ -1,9 +1,9 @@
-/* eslint-disable import/no-extraneous-dependencies, import/no-unresolved, import/extensions */
+import {configure} from '@storybook/react'
 
-import { configure } from '@storybook/react'
+const req = require.context('../', true, /Foo.example.js$/)
 
-function loadStories() {
-  require('../stories')
+function loadStories () {
+  req.keys().forEach(req)
 }
 
 configure(loadStories, module)

--- a/Foo.example.js
+++ b/Foo.example.js
@@ -1,0 +1,10 @@
+import React from 'react'
+import styled from 'styled-components'
+import { storiesOf } from '@storybook/react'
+
+const Foo = () => {
+  return <span className='classname'>Foo</span>
+}
+
+storiesOf('Foo')
+  .add('default', () => <Foo>Hello</Foo>)

--- a/__snapshots__/Storyshots.test.js.snap
+++ b/__snapshots__/Storyshots.test.js.snap
@@ -38,6 +38,16 @@ exports[`Storyshots Button with text 1`] = `
 </button>
 `;
 
+exports[`Storyshots Foo default 1`] = `
+
+
+<span
+  className="classname"
+>
+  Foo
+</span>
+`;
+
 exports[`Storyshots Welcome to Storybook 1`] = `
 <div
   style={

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "babel-preset-es2015": "^6.24.1",
     "babel-preset-react": "^6.24.1",
     "husky": "^0.13.4",
-    "jest-styled-components": "^3.1.0",
+    "jest-styled-components": "^3.1.3",
     "lint-staged": "^4.0.0",
     "prettier-standard": "^5.1.0",
     "react-test-renderer": "^15.6.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -3436,9 +3436,9 @@ jest-snapshot@^20.0.3:
     natural-compare "^1.4.0"
     pretty-format "^20.0.3"
 
-jest-styled-components@^3.1.0:
-  version "3.1.0"
-  resolved "https://registry.yarnpkg.com/jest-styled-components/-/jest-styled-components-3.1.0.tgz#3687b1a564b16241d19bb8ecea1e6b477d4e0c0c"
+jest-styled-components@^3.1.3:
+  version "3.1.3"
+  resolved "https://registry.yarnpkg.com/jest-styled-components/-/jest-styled-components-3.1.3.tgz#eba50074b426e36fd2be99187dffa4b5569eab00"
   dependencies:
     css "^2.2.1"
 


### PR DESCRIPTION
This component has a class, but is not using jest-styled-components

If you run the test it produces the following error:

```
FAIL  ./Storyshots.test.js
  ● Storyshots › Foo › default

    TypeError: Cannot read property '1' of null

      at Object.styledSnapshot [as test] (Storyshots.test.js:10:16)
      at process._tickCallback (internal/process/next_tick.js:109:7)

  Storyshots
    Foo
      ✕ default (5ms)

Snapshot Summary
 › 3 obsolete snapshots found, press `u` to remove them.

Test Suites: 1 failed, 1 total
Tests:       1 failed, 1 total
Snapshots:   0 total
Time:        1.626s
Ran all test suites.

Watch Usage: Press w to show more.
```